### PR TITLE
Different format of log message for fedora-systems

### DIFF
--- a/Sanity/simple-bind-luks/runtest.sh
+++ b/Sanity/simple-bind-luks/runtest.sh
@@ -87,9 +87,7 @@ rlJournalStart
 
         rlRun "packageVersion=$(rpm -q ${PACKAGE} --qf '%{name}-%{version}-%{release}\n')"
         if rlTestVersion "${packageVersion}" '>=' 'clevis-15-8'; then
-            rlAssertGrep "Error communicating with the server http://localhost" $rlRun_LOG
-        else
-            rlAssertGrep "Error communicating with the server!" $rlRun_LOG
+            rlAssertGrep "Error communicating with .*server http://localhost" $rlRun_LOG -Eq
         fi
         rm $rlRun_LOG
 


### PR DESCRIPTION
For fedora system is different format of message than in Rhel's. Adjust grep to catch it properly for each type of system.


https://github.com/RedHat-SP-Security/tests/pull/137 