### PR TITLE
Use curl instead of wget in the tests

### DIFF
--- a/Sanity/bind-luks/Makefile
+++ b/Sanity/bind-luks/Makefile
@@ -54,7 +54,7 @@ $(METADATA): Makefile
 	@echo "Type:            Sanity" >> $(METADATA)
 	@echo "TestTime:        5m" >> $(METADATA)
 	@echo "RunFor:          clevis tang jose" >> $(METADATA)
-	@echo "Requires:        clevis clevis-luks luksmeta tang expect socat psmisc wget" >> $(METADATA)
+	@echo "Requires:        clevis clevis-luks luksmeta tang expect socat psmisc curl" >> $(METADATA)
 	@echo "Priority:        Normal" >> $(METADATA)
 	@echo "License:         GPLv2" >> $(METADATA)
 	@echo "Confidential:    no" >> $(METADATA)

--- a/Sanity/bind-luks/main.fmf
+++ b/Sanity/bind-luks/main.fmf
@@ -18,7 +18,7 @@ recommend:
   - expect
   - socat
   - psmisc
-  - wget
+  - curl
 duration: 5m
 enabled: true
 tag:

--- a/Sanity/kernel-keyring-support/Makefile
+++ b/Sanity/kernel-keyring-support/Makefile
@@ -56,7 +56,7 @@ $(METADATA): Makefile
 	@echo "Type:            Sanity" >> $(METADATA)
 	@echo "TestTime:        5m" >> $(METADATA)
 	@echo "RunFor:          clevis" >> $(METADATA)
-	@echo "Requires:        clevis-luks tang keyutils" >> $(METADATA)
+	@echo "Requires:        clevis-luks tang keyutils curl" >> $(METADATA)
 	@echo "Priority:        Normal" >> $(METADATA)
 	@echo "License:         GPLv2+" >> $(METADATA)
 	@echo "Confidential:    no" >> $(METADATA)

--- a/Sanity/kernel-keyring-support/main.fmf
+++ b/Sanity/kernel-keyring-support/main.fmf
@@ -21,6 +21,7 @@ recommend:
   - clevis-luks
   - tang
   - keyutils
+  - curl
 duration: 5m
 extra-nitrate: TC#0614663
 extra-summary: /CoreOS/clevis/Sanity/kernel-keyring-support

--- a/Sanity/kernel-keyring-support/runtest.sh
+++ b/Sanity/kernel-keyring-support/runtest.sh
@@ -60,7 +60,7 @@ rlJournalStart
 
         rlRun "rlServiceStart tangd.socket"
         rlRun "sleep 1"
-        rlRun "wget -nv -O adv.json \"http://localhost/adv\"" 0 "Get advertisement from tang server"
+        rlRun "curl -sS -o adv.json \"http://localhost/adv\"" 0 "Get advertisement from tang server"
 
         rlRun "dd if=/dev/zero of=loopfile bs=100M count=1" 0 "Create dummy file for device"
         rlRun "lodev=$(losetup -f --show loopfile)" 0 "Create device"

--- a/Sanity/luks-list/Makefile
+++ b/Sanity/luks-list/Makefile
@@ -53,7 +53,7 @@ $(METADATA): Makefile
 	@echo "Type:            Sanity" >> $(METADATA)
 	@echo "TestTime:        5m" >> $(METADATA)
 	@echo "RunFor:          clevis" >> $(METADATA)
-	@echo "Requires:        clevis clevis-luks tang wget" >> $(METADATA)
+	@echo "Requires:        clevis clevis-luks tang curl" >> $(METADATA)
 	@echo "Priority:        Normal" >> $(METADATA)
 	@echo "License:         GPLv2+" >> $(METADATA)
 	@echo "Confidential:    no" >> $(METADATA)

--- a/Sanity/luks-list/main.fmf
+++ b/Sanity/luks-list/main.fmf
@@ -4,7 +4,7 @@ recommend:
   - clevis
   - clevis-luks
   - tang
-  - wget
+  - curl
 duration: 5m
 enabled: true
 tag:

--- a/Sanity/luks-list/runtest.sh
+++ b/Sanity/luks-list/runtest.sh
@@ -69,7 +69,7 @@ rlJournalStart
 
     rlPhaseStartTest "clevis luks bind"
         rlRun "luksmeta show -d ${lodev} -s 1" "1-100" "Check if there is no luksmeta data in slot 1"
-        rlRun "wget -nv -O adv.json \"http://localhost/adv\"" 0 "Get advertisement from tang server"
+        rlRun "curl -sS -o adv.json \"http://localhost/adv\"" 0 "Get advertisement from tang server"
 
         rlRun  "echo -n redhat123 | clevis luks bind -f -k - -d ${lodev} tang '{ \"url\": \"http://localhost\", \"adv\": \"adv.json\" }'" 0 "clevis luks bind"
 

--- a/Sanity/luks-pass/Makefile
+++ b/Sanity/luks-pass/Makefile
@@ -53,7 +53,7 @@ $(METADATA): Makefile
 	@echo "Type:            Sanity" >> $(METADATA)
 	@echo "TestTime:        5m" >> $(METADATA)
 	@echo "RunFor:          clevis" >> $(METADATA)
-	@echo "Requires:        clevis clevis-luks tang jose cryptsetup wget" >> $(METADATA)
+	@echo "Requires:        clevis clevis-luks tang jose cryptsetup curl" >> $(METADATA)
 	@echo "Priority:        Normal" >> $(METADATA)
 	@echo "License:         GPLv2+" >> $(METADATA)
 	@echo "Confidential:    no" >> $(METADATA)

--- a/Sanity/luks-pass/main.fmf
+++ b/Sanity/luks-pass/main.fmf
@@ -7,7 +7,7 @@ recommend:
   - tang
   - jose
   - cryptsetup
-  - wget
+  - curl
 duration: 5m
 enabled: true
 tag:

--- a/Sanity/luks-pass/runtest.sh
+++ b/Sanity/luks-pass/runtest.sh
@@ -53,7 +53,7 @@ rlJournalStart
 
     rlPhaseStartTest "clevis luks bind"
         rlRun "luksmeta show -d ${lodev} -s 1" "1-100" "Check if there is no luksmeta data in slot 1"
-        rlRun "wget -nv -O adv.json \"http://localhost/adv\"" 0 "Get advertisement from tang server"
+        rlRun "curl -sS -o adv.json \"http://localhost/adv\"" 0 "Get advertisement from tang server"
 
         rlRun  "echo -n redhat123 | clevis luks bind -f -k - -d ${lodev} tang '{ \"url\": \"http://localhost\", \"adv\": \"adv.json\" }'" 0 "clevis luks bind"
 

--- a/Sanity/pin-sss/Makefile
+++ b/Sanity/pin-sss/Makefile
@@ -54,7 +54,7 @@ $(METADATA): Makefile
 	@echo "Type:            Sanity" >> $(METADATA)
 	@echo "TestTime:        5m" >> $(METADATA)
 	@echo "RunFor:          clevis tang jose luksmeta" >> $(METADATA)
-	@echo "Requires:        clevis tang socat expect psmisc wget" >> $(METADATA)
+	@echo "Requires:        clevis tang socat expect psmisc curl" >> $(METADATA)
 	@echo "Priority:        Normal" >> $(METADATA)
 	@echo "License:         GPLv2" >> $(METADATA)
 	@echo "Confidential:    no" >> $(METADATA)

--- a/Sanity/pin-sss/main.fmf
+++ b/Sanity/pin-sss/main.fmf
@@ -10,7 +10,7 @@ recommend:
   - socat
   - expect
   - psmisc
-  - wget
+  - curl
 duration: 5m
 enabled: true
 tag:

--- a/Sanity/pin-sss/runtest.sh
+++ b/Sanity/pin-sss/runtest.sh
@@ -111,8 +111,8 @@ rlJournalStart
     if [ $(rpm -q --queryformat '%{VERSION}' clevis) -ge 15 ]; then
         # Tests feature added in clevis-15.1 for RHEL-8.4
         rlPhaseStart FAIL "Valid sss config with wrong tang config"
-            rlRun "wget -nv -O adv1.json \"http://localhost:$port1/adv\""
-            rlRun "wget -nv -O adv2.json \"http://localhost:$port2/adv\""
+            rlRun "curl -sS -o adv1.json \"http://localhost:$port1/adv\""
+            rlRun "curl -sS -o adv2.json \"http://localhost:$port2/adv\""
             echo -n "testing data string" > plain
             rlRun "clevis encrypt sss '{
                     \"t\": 2,
@@ -128,9 +128,9 @@ rlJournalStart
     fi
 
     rlPhaseStart FAIL "clevis setup, encrypt using t=2 and 3 servers"
-        rlRun "wget -nv -O adv1.json \"http://localhost:$port1/adv\""
-        rlRun "wget -nv -O adv2.json \"http://localhost:$port2/adv\""
-        rlRun "wget -nv -O adv3.json \"http://localhost:$port3/adv\""
+        rlRun "curl -sS -o adv1.json \"http://localhost:$port1/adv\""
+        rlRun "curl -sS -o adv2.json \"http://localhost:$port2/adv\""
+        rlRun "curl -sS -o adv3.json \"http://localhost:$port3/adv\""
         echo -n "testing data string" > plain
         rlRun "clevis encrypt sss '{
                 \"t\": 2,

--- a/Sanity/pin-tang/Makefile
+++ b/Sanity/pin-tang/Makefile
@@ -54,7 +54,7 @@ $(METADATA): Makefile
 	@echo "Type:            Sanity" >> $(METADATA)
 	@echo "TestTime:        5m" >> $(METADATA)
 	@echo "RunFor:          clevis tang jose luksmeta" >> $(METADATA)
-	@echo "Requires:        clevis tang socat expect psmisc wget" >> $(METADATA)
+	@echo "Requires:        clevis tang socat expect psmisc curl" >> $(METADATA)
 	@echo "Priority:        Normal" >> $(METADATA)
 	@echo "License:         GPLv2" >> $(METADATA)
 	@echo "Confidential:    no" >> $(METADATA)

--- a/Sanity/pin-tang/main.fmf
+++ b/Sanity/pin-tang/main.fmf
@@ -10,7 +10,7 @@ recommend:
   - socat
   - expect
   - psmisc
-  - wget
+  - curl
 duration: 5m
 enabled: true
 tag:

--- a/Sanity/pin-tang/runtest.sh
+++ b/Sanity/pin-tang/runtest.sh
@@ -122,7 +122,7 @@ CLEVIS_END
     rlPhaseEnd
 
     rlPhaseStart FAIL "clevis encrypt, using existing adv"
-        rlRun "wget -nv -O adv.json \"http://localhost:$port/adv\""
+        rlRun "curl -sS -o adv.json \"http://localhost:$port/adv\""
         stop_tang "$port"
         echo -n "testing data string" > plain
         rlRun "clevis encrypt tang '{ \"url\": \"http://localhost:8123\", \"adv\": \"adv.json\" }' < plain > enc"

--- a/Sanity/simple-bind-luks/Makefile
+++ b/Sanity/simple-bind-luks/Makefile
@@ -53,7 +53,7 @@ $(METADATA): Makefile
 	@echo "Type:            Sanity" >> $(METADATA)
 	@echo "TestTime:        5m" >> $(METADATA)
 	@echo "RunFor:          clevis" >> $(METADATA)
-	@echo "Requires:        clevis-luks tang wget" >> $(METADATA)
+	@echo "Requires:        clevis-luks tang curl" >> $(METADATA)
 	@echo "Priority:        Normal" >> $(METADATA)
 	@echo "License:         GPLv2+" >> $(METADATA)
 	@echo "Confidential:    no" >> $(METADATA)

--- a/Sanity/simple-bind-luks/main.fmf
+++ b/Sanity/simple-bind-luks/main.fmf
@@ -3,7 +3,7 @@ test: ./runtest.sh
 recommend:
   - clevis-luks
   - tang
-  - wget
+  - curl
 duration: 5m
 enabled: true
 tag:

--- a/Sanity/simple-bind-luks/runtest.sh
+++ b/Sanity/simple-bind-luks/runtest.sh
@@ -48,7 +48,7 @@ rlJournalStart
 
     rlPhaseStartTest "clevis luks bind"
         rlRun "luksmeta show -d ${lodev} -s 1" "1-100" "Check if there is no luksmeta data in slot 1"
-        rlRun "wget -nv -O adv.json \"http://localhost/adv\"" 0 "Get advertisement from tang server"
+        rlRun "curl -sS -o adv.json \"http://localhost/adv\"" 0 "Get advertisement from tang server"
 
         rlRun -s "echo -n redhat123 | clevis luks bind -f -k - -d ${lodev} tang '{ \"url\": \"http://localhost\", \"adv\": \"adv.json\" }'" 0 "clevis luks bind"
 

--- a/Sanity/simple-encrypt-pin-tang/Makefile
+++ b/Sanity/simple-encrypt-pin-tang/Makefile
@@ -53,7 +53,7 @@ $(METADATA): Makefile
 	@echo "Type:            Sanity" >> $(METADATA)
 	@echo "TestTime:        5m" >> $(METADATA)
 	@echo "RunFor:          clevis" >> $(METADATA)
-	@echo "Requires:        clevis tang wget" >> $(METADATA)
+	@echo "Requires:        clevis tang curl" >> $(METADATA)
 	@echo "Priority:        Normal" >> $(METADATA)
 	@echo "License:         GPLv2+" >> $(METADATA)
 	@echo "Confidential:    no" >> $(METADATA)

--- a/Sanity/simple-encrypt-pin-tang/main.fmf
+++ b/Sanity/simple-encrypt-pin-tang/main.fmf
@@ -3,7 +3,7 @@ test: ./runtest.sh
 recommend:
   - clevis
   - tang
-  - wget
+  - curl
 duration: 5m
 enabled: true
 tag:

--- a/Sanity/simple-encrypt-pin-tang/runtest.sh
+++ b/Sanity/simple-encrypt-pin-tang/runtest.sh
@@ -41,7 +41,7 @@ rlJournalStart
 
         rlRun "rlServiceStart tangd.socket"
         rlRun "sleep 1"
-        rlRun "wget -nv -O adv.json \"http://localhost/adv\"" 0 "Get advertisement from tang server"
+        rlRun "curl -sS -o adv.json \"http://localhost/adv\"" 0 "Get advertisement from tang server"
 
         echo "testing data string" > plainFile
     rlPhaseEnd

--- a/Sanity/tang-high-availability/Makefile
+++ b/Sanity/tang-high-availability/Makefile
@@ -54,7 +54,7 @@ $(METADATA): Makefile
 	@echo "Type:            Sanity" >> $(METADATA)
 	@echo "TestTime:        5m" >> $(METADATA)
 	@echo "RunFor:          clevis tang" >> $(METADATA)
-	@echo "Requires:        clevis tang jose socat expect psmisc wget" >> $(METADATA)
+	@echo "Requires:        clevis tang jose socat expect psmisc curl" >> $(METADATA)
 	@echo "Priority:        Normal" >> $(METADATA)
 	@echo "License:         GPLv2" >> $(METADATA)
 	@echo "Confidential:    no" >> $(METADATA)

--- a/Sanity/tang-high-availability/main.fmf
+++ b/Sanity/tang-high-availability/main.fmf
@@ -10,7 +10,7 @@ recommend:
   - socat
   - expect
   - psmisc
-  - wget
+  - curl
 duration: 5m
 enabled: true
 tag:

--- a/Sanity/tang-high-availability/runtest.sh
+++ b/Sanity/tang-high-availability/runtest.sh
@@ -95,7 +95,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStart FAIL "clevis encrypt using first server, decrypt using second"
-        rlRun "wget -nv -O adv.json \"http://localhost:$port/adv\""
+        rlRun "curl -sS -o adv.json \"http://localhost:$port/adv\""
         echo -n "testing data string" > plain
         rlRun "clevis encrypt tang '{ \"url\": \"http://localhost:$port\", \"adv\": \"adv.json\" }' < plain > enc"
         grep_b64 "http:" enc


### PR DESCRIPTION
As wget is being replaced with wget2[1], some issues started appearing with the tests, so let's use curl instead.

[1] https://fedoraproject.org/wiki/Changes/Wget2asWget