### PR TITLE
PKCS11 and tpm2 basic test cases

### DIFF
--- a/Sanity/pkcs11/basic/runtest.sh
+++ b/Sanity/pkcs11/basic/runtest.sh
@@ -49,13 +49,7 @@ rlJournalStart
         create_hsm_config
 
         export SOFTHSM2_CONF=$TMPDIR/softhsm.conf
-        TOKEN_LABEL="test_token"
-        SOFTHSM_LIB="/usr/lib64/softhsm/libsofthsm.so"
-        PINVALUE=1234
-        ID="0001"
-
-        rlRun -l "softhsm2-util --init-token --label $TOKEN_LABEL --free --pin $PINVALUE --so-pin $PINVALUE" 0 "Initialize token"
-        rlRun -l "pkcs11-tool --keypairgen --key-type="rsa:2048" --login --pin=$PINVALUE --module=$SOFTHSM_LIB --label=$TOKEN_LABEL --id=$ID" 0 "Generating a new key pair"
+        create_token
 
         # Get serial number of the token
         TOKEN_SERIAL_NUM=$(pkcs11-tool --module $SOFTHSM_LIB -L | grep "serial num" | awk '{print $4}')

--- a/Sanity/pkcs11/basic/runtest.sh
+++ b/Sanity/pkcs11/basic/runtest.sh
@@ -71,45 +71,50 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStart FAIL "Simple text encryption and decryption (pin-source)"
-        # TODO: THE PIN-SOURCE attribute not yet implemented so this test case will fail
-        rlRun "echo $PINVALUE > $PWD/pin"
-        URI="{\"uri\": \"pkcs11:model=SoftHSM%20v2;manufacturer=SoftHSM%20project;serial=$TOKEN_SERIAL_NUM;token=$TOKEN_LABEL;id=$ID;module-path=$SOFTHSM_LIB?pin-source=$PWD/pin\", \"mechanism\": \"RSA-PKCS\"}"
-        rlRun "echo 'this is a secret 2' > plain_text" 0 "Create a file to encrypt"
-        rlRun "clevis encrypt pkcs11 '$URI' < plain_text > JWE" 0 "Encrypting the plain text"
+        # TODO: Uncomment once implemention is finished:
+        #   - THE PIN-SOURCE attribute not yet implemented
 
-        rlAssertDiffer JWE plain_text
+        # rlRun "echo $PINVALUE > $PWD/pin"
+        # URI="{\"uri\": \"pkcs11:model=SoftHSM%20v2;manufacturer=SoftHSM%20project;serial=$TOKEN_SERIAL_NUM;token=$TOKEN_LABEL;id=$ID;module-path=$SOFTHSM_LIB?pin-source=$PWD/pin\", \"mechanism\": \"RSA-PKCS\"}"
+        # rlRun "echo 'this is a secret 2' > plain_text" 0 "Create a file to encrypt"
+        # rlRun "clevis encrypt pkcs11 '$URI' < plain_text > JWE" 0 "Encrypting the plain text"
 
-        rlRun "clevis decrypt pkcs11 < JWE > decrypted_message" 0 "Decrypting the JWE"
-        rlAssertNotDiffer decrypted_message plain_text
-        rlRun "rm plain_text decrypted_message JWE $PWD/pin"
+        # rlAssertDiffer JWE plain_text
+
+        # rlRun "clevis decrypt pkcs11 < JWE > decrypted_message" 0 "Decrypting the JWE"
+        # rlAssertNotDiffer decrypted_message plain_text
+        # rlRun "rm plain_text decrypted_message JWE $PWD/pin"
     rlPhaseEnd
 
     rlPhaseStart FAIL "clevis pkcs11 - Simple text encryption and decryption (empty pkcs11 URI)"
-        # TODO: The token is not found unless the module-path is specified
-        # TODO: Clevis does not ask for a password when encrypting/decrypting thus failing to decrypt the message
-        rlRun "echo 'this is secret 3' > plain_text" 0 "Create a file to encrypt"
-        URI="{\"uri\": \"pkcs11:\", \"mechanism\": \"RSA-PKCS\"}"
-        rlRun "clevis encrypt pkcs11 '$URI' < plain_text > JWE" 0 "Encrypting the plain text"
+        # TODO: Uncomment once implemention is finished:
+        #   - Clevis does not ask for a password when encrypting/decrypting thus failing to decrypt the message
 
-        rlAssertDiffer JWE plain_text
+        # rlRun "echo 'this is secret 3' > plain_text" 0 "Create a file to encrypt"
+        # # (the module-path should be used because softhsm is a software token and not hardware one)
+        # URI="{\"uri\": \"pkcs11:module-path=$SOFTHSM_LIB\", \"mechanism\": \"RSA-PKCS\"}"
+        # rlRun "clevis encrypt pkcs11 '$URI' < plain_text > JWE" 0 "Encrypting the plain text"
 
-        # The clevis should also ask for a password
-        rlRun "clevis decrypt pkcs11 < JWE > decrypted_message" 0 "Decrypting the JWE"
-        rlAssertNotDiffer decrypted_message plain_text
-        rlRun "rm plain_text decrypted_message JWE"
+        # rlAssertDiffer JWE plain_text
+
+        # # The clevis should also ask for a password
+        # rlRun "clevis decrypt pkcs11 < JWE > decrypted_message" 0 "Decrypting the JWE"
+        # rlAssertNotDiffer decrypted_message plain_text
+        # rlRun "rm plain_text decrypted_message JWE"
     rlPhaseEnd
 
     rlPhaseStart FAIL "Simple text encryption and decryption (RSA-PKCS-OAEP mechanism)"
-        # TODO: THE RSA-PKCS-OAEP mechanism is not implemented in the softhsm so this test case will fail
-        URI="{\"uri\": \"pkcs11:model=SoftHSM%20v2;manufacturer=SoftHSM%20project;serial=$TOKEN_SERIAL_NUM;token=$TOKEN_LABEL;id=$ID;module-path=$SOFTHSM_LIB?pin-value=$PINVALUE\", \"mechanism\": \"RSA-PKCS-OAEP\"}"
-        rlRun "echo 'this is a secret 4' > plain_text" 0 "Create a file to encrypt"
-        rlRun "clevis encrypt pkcs11 '$URI' < plain_text > JWE" 0 "Encrypting the plain text"
+        # TODO: Uncomment once implemention is finished:
+        #   - THE RSA-PKCS-OAEP mechanism is not implemented in the softhsm
+        # URI="{\"uri\": \"pkcs11:model=SoftHSM%20v2;manufacturer=SoftHSM%20project;serial=$TOKEN_SERIAL_NUM;token=$TOKEN_LABEL;id=$ID;module-path=$SOFTHSM_LIB?pin-value=$PINVALUE\", \"mechanism\": \"RSA-PKCS-OAEP\"}"
+        # rlRun "echo 'this is a secret 4' > plain_text" 0 "Create a file to encrypt"
+        # rlRun "clevis encrypt pkcs11 '$URI' < plain_text > JWE" 0 "Encrypting the plain text"
 
-         rlAssertDiffer JWE plain_text
+        #  rlAssertDiffer JWE plain_text
 
-        rlRun "clevis decrypt pkcs11 < JWE > decrypted_message" 0 "Decrypting the JWE"
-        rlAssertNotDiffer decrypted_message plain_text
-        rlRun "rm plain_text decrypted_message JWE $PWD/pin"
+        # rlRun "clevis decrypt pkcs11 < JWE > decrypted_message" 0 "Decrypting the JWE"
+        # rlAssertNotDiffer decrypted_message plain_text
+        # rlRun "rm plain_text decrypted_message JWE $PWD/pin"
     rlPhaseEnd
 
     rlPhaseStart FAIL "Simple text encryption and decryption (card removal before decryption)"

--- a/Sanity/pkcs11/basic/runtest.sh
+++ b/Sanity/pkcs11/basic/runtest.sh
@@ -126,7 +126,7 @@ rlJournalStart
         rlAssertDiffer JWE plain_text
 
         rlRun "softhsm2-util --delete-token --token $TOKEN_LABEL" 0 "Delete the token to simulate card removal"
-        rlRun -l "clevis decrypt pkcs11 < JWE" 1 "It is expected to fail the decryption as the card token was deleted"
+        rlRun -l "clevis decrypt pkcs11 < JWE" 1 "It is expected to fail the decryption as the token card was deleted"
         rlRun "rm plain_text JWE"
     rlPhaseEnd
 

--- a/Sanity/pkcs11/luks-tpm2/main.fmf
+++ b/Sanity/pkcs11/luks-tpm2/main.fmf
@@ -1,4 +1,4 @@
-summary: tests the basic pkcs#11 luks functionality of clevis
+summary: tests the basic pkcs#11 luks and tpm2 functionality of clevis
 component:
   - clevis
 test: ./runtest.sh
@@ -11,7 +11,7 @@ recommend:
   - openssl
   - a2x
   - git
-duration: 10m
+duration: 20m
 enabled: true
 tag:
   - NoRHEL4

--- a/Sanity/pkcs11/luks-tpm2/runtest.sh
+++ b/Sanity/pkcs11/luks-tpm2/runtest.sh
@@ -2,7 +2,7 @@
 # vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
-#   runtest.sh of /CoreOS/clevis/Sanity/pkcs11/luks
+#   runtest.sh of /CoreOS/clevis/Sanity/pkcs11/luks-tpm2
 #   Description: tests the basic pkcs11 luks functionality of clevis
 #   Author: Martin Litwora <mlitwora@redhat.com>
 #
@@ -50,13 +50,8 @@ rlJournalStart
         create_hsm_config
 
         export SOFTHSM2_CONF=$TMPDIR/softhsm.conf
-        TOKEN_LABEL="test_token"
-        SOFTHSM_LIB="/usr/lib64/softhsm/libsofthsm.so"
-        PINVALUE=1234
-        ID="0001"
 
-        rlRun -l "softhsm2-util --init-token --label $TOKEN_LABEL --free --pin $PINVALUE --so-pin $PINVALUE" 0 "Initialize token"
-        rlRun -l "pkcs11-tool --keypairgen --key-type="rsa:2048" --login --pin=$PINVALUE --module=$SOFTHSM_LIB --label=$TOKEN_LABEL --id=$ID" 0 "Generating a new key pair"
+        create_token
 
         # Get serial number of the token
         TOKEN_SERIAL_NUM=$(pkcs11-tool --module $SOFTHSM_LIB -L | grep "serial num" | awk '{print $4}')
@@ -85,11 +80,10 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStart FAIL "clevis luks pkcs11 - two factor disk encryption"
-        Create a token as it was removed in previous test case
-        rlRun -l "softhsm2-util --init-token --label $TOKEN_LABEL --free --pin $PINVALUE --so-pin $PINVALUE" 0 "Initialize token"
-        rlRun -l "pkcs11-tool --keypairgen --key-type="rsa:2048" --login --pin=$PINVALUE --module=$SOFTHSM_LIB --label=$TOKEN_LABEL --id=$ID" 0 "Generating a new key pair"
-        rlRun -l "pkcs11-tool -L --module=$SOFTHSM_LIB"
-        Get serial number of the token
+        # Create a token as it was removed in previous test case
+        create_token
+
+        # Get serial number of the token
         TOKEN_SERIAL_NUM=$(pkcs11-tool --module $SOFTHSM_LIB -L | grep "serial num" | awk '{print $4}')
         rlAssertNotEquals "Test that the serial number is not empty" "" $TOKEN_SERIAL_NUM
         URI="{\"uri\": \"pkcs11:model=SoftHSM%20v2;manufacturer=SoftHSM%20project;serial=$TOKEN_SERIAL_NUM;token=$TOKEN_LABEL;id=$ID;module-path=$SOFTHSM_LIB?pin-value=$PINVALUE\", \"mechanism\": \"RSA-PKCS\"}"
@@ -113,6 +107,74 @@ rlJournalStart
 
         rlRun "clevis luks unbind -d ${lodev} -s 1 -f"
         rlRun "rm grep_output"
+    rlPhaseEnd
+
+    rlPhaseStart FAIL "Simple text encryption and decryption two factor - threshold 2 (both the pkcs11 and TPM2 module present)"
+        # Create a token as it was removed in previous test case
+        create_token
+
+        # Get serial number of the token
+        TOKEN_SERIAL_NUM=$(pkcs11-tool --module $SOFTHSM_LIB -L | grep "serial num" | awk '{print $4}')
+
+        rlRun "echo 'this is a secret 1' > plain_text" 0 "Create a file to encrypt"
+        rlRun "clevis encrypt sss '{
+                    \"t\": 2,
+                    \"pins\": {
+                        \"pkcs11\": $URI,
+                        \"tpm2\": {}
+                    }
+                }' < plain_text > JWE"
+
+        rlAssertDiffer JWE plain_text
+
+        rlRun "clevis decrypt sss < JWE > decrypted_message" 0 "Decrypting the JWE"
+        rlAssertNotDiffer decrypted_message plain_text
+        rlRun "rm plain_text decrypted_message JWE"
+    rlPhaseEnd
+
+    rlPhaseStart FAIL "Simple text encryption and decryption two factor - threshold 2 (pkcs11 removed)"
+        rlRun "echo 'this is a secret 2' > plain_text" 0 "Create a file to encrypt"
+        rlRun "clevis encrypt sss '{
+                    \"t\": 2,
+                    \"pins\": {
+                        \"pkcs11\": $URI,
+                        \"tpm2\": {}
+                    }
+                }' < plain_text > JWE"
+
+        rlAssertDiffer JWE plain_text
+
+        rlRun "softhsm2-util --delete-token --token $TOKEN_LABEL" 0 "Delete the token to simulate card removal"
+
+        rlRun "clevis decrypt sss < JWE" 1 "It is expected to fail the decryption as the token card was deleted"
+        rlRun "rm plain_text JWE"
+    rlPhaseEnd
+
+    rlPhaseStart FAIL "Simple text encryption and decryption two factor - threshold 1 (pkcs11 removed)"
+        # Create a token as it was removed in previous test case
+        create_token
+
+        # Get serial number of the token
+        TOKEN_SERIAL_NUM=$(pkcs11-tool --module $SOFTHSM_LIB -L | grep "serial num" | awk '{print $4}')
+        URI="{\"uri\": \"pkcs11:model=SoftHSM%20v2;manufacturer=SoftHSM%20project;serial=$TOKEN_SERIAL_NUM;token=$TOKEN_LABEL;id=$ID;module-path=$SOFTHSM_LIB?pin-value=$PINVALUE\", \"mechanism\": \"RSA-PKCS\"}"
+        rlAssertNotEquals "Test that the serial number is not empty" "" $TOKEN_SERIAL_NUM
+
+        rlRun "echo 'this is a secret 3' > plain_text" 0 "Create a file to encrypt"
+        rlRun "clevis encrypt sss '{
+                    \"t\": 1,
+                    \"pins\": {
+                        \"pkcs11\": $URI,
+                        \"tpm2\": {}
+                    }
+                }' < plain_text > JWE"
+
+        rlAssertDiffer JWE plain_text
+
+        rlRun "softhsm2-util --delete-token --token $TOKEN_LABEL" 0 "Delete the token to simulate card removal"
+
+        rlRun "clevis decrypt sss < JWE > decrypted_message" 0 "Decrypting the JWE"
+        rlAssertNotDiffer decrypted_message plain_text
+        rlRun "rm plain_text decrypted_message JWE"
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/Sanity/pkcs11/single-encrypted-disk/runtest.sh
+++ b/Sanity/pkcs11/single-encrypted-disk/runtest.sh
@@ -95,12 +95,7 @@ rlJournalStart
 
             install_softhsm
 
-            TOKEN_LABEL="test_token"
-            SOFTHSM_LIB="/usr/lib64/softhsm/libsofthsm.so"
-            PINVALUE=1234
-            ID="0001"
-            rlRun -l "softhsm2-util --init-token --label $TOKEN_LABEL --free --pin $PINVALUE --so-pin $PINVALUE" 0 "Initialize token"
-            rlRun -l "pkcs11-tool --keypairgen --key-type="rsa:2048" --login --pin=$PINVALUE --module=$SOFTHSM_LIB --label=$TOKEN_LABEL --id=$ID" 0 "Generating a new key pair"
+            create_token
 
             # Get serial number of the token
             TOKEN_SERIAL_NUM=$(pkcs11-tool --module $SOFTHSM_LIB -L | grep "serial num" | awk '{print $4}')

--- a/TestHelpers/utils.sh
+++ b/TestHelpers/utils.sh
@@ -57,3 +57,18 @@ prepare_dracut() {
         rlRun "dracut -f -v --include $SOFTHSM_LIB $SOFTHSM_LIB --include /etc/softhsm2.conf /etc/softhsm2.conf" 0 "Include softhsm libraries in initramfs"
     rlPhaseEnd
 }
+
+create_token() {
+    # Create a softhsm token
+    rlPhaseStart FAIL "create softhsm token"
+        TOKEN_LABEL="test_token"
+        SOFTHSM_LIB="/usr/lib64/softhsm/libsofthsm.so"
+        PINVALUE=1234
+        ID="0001"
+
+        rlRun -l "softhsm2-util --init-token --label $TOKEN_LABEL --free --pin $PINVALUE --so-pin $PINVALUE" 0 "Initialize token"
+        rlRun -l "pkcs11-tool --keypairgen --key-type="rsa:2048" --login --pin=$PINVALUE --module=$SOFTHSM_LIB --label=$TOKEN_LABEL --id=$ID" 0 "Generating a new key pair"
+
+        rlRun -l "pkcs11-tool -L --module=$SOFTHSM_LIB"
+    rlPhaseEnd
+}


### PR DESCRIPTION
This PR adds the following:

- Test cases using the pkcs11 and tpm2 module together for SSS option of the Clevis (scenario 4 described here https://docs.google.com/document/d/1JSG_wXTId-VO8UGgDVpaVUWINqSMTqgnj6YBQLPqigM/edit?usp=sharing)
- move token creation into `TestHelpers/utils.sh` so it can be used easily in different tests
- comment out failing tests in pkcs11 (they are failing because of the missing implementation)

Ref: https://issues.redhat.com/browse/SECENGSP-6154
