### PR TITLE
Disable test by default, enable only with context

### DIFF
--- a/Plans/ci.fmf
+++ b/Plans/ci.fmf
@@ -32,6 +32,8 @@ execute:
         - Sanity/pkcs11/luks
 
 /pkcs11-single-encrypted-disk:
+    context:
+      kickstart_pkcs11: true
     provision:
       hardware:
         disk:

--- a/Sanity/pkcs11/single-encrypted-disk/main.fmf
+++ b/Sanity/pkcs11/single-encrypted-disk/main.fmf
@@ -28,3 +28,6 @@ adjust:
   - enabled: false
     when: distro == rhel-4, rhel-5, rhel-6, rhel-7, rhel-8
     continue: false
+  - when: kickstart_pkcs11 is not defined or kickstart_pkcs11 == false
+    enabled: false
+    because: This tests works only with provisioned kickstart file in plan and minimal hardware reqs.


### PR DESCRIPTION
Test is now disabled by default, need to set context for enabling.