### PR TITLE
Adjust unlock boot scenario to use TLS

### DIFF
--- a/Other/clevis-boot-unlock-all-pins/clevis-boot-unlock-all-pins
+++ b/Other/clevis-boot-unlock-all-pins/clevis-boot-unlock-all-pins
@@ -15,15 +15,21 @@ echo "#######################"
   # Sanity check.
   skip=
   [ -z "${TANG_SERVER}" ] && skip=true
-
   #check if tpm device exist
   [ -e /dev/tpm0 ] || skip=true
   for _pkg in ${REQ_PKGS}; do
     rpm -q "${_pkg}" >/dev/null || skip=true
   done
+  echo "Configuring trust for Tang server certificate..."
+  cp /data/shared-files/server.crt /etc/pki/ca-trust/source/anchors/server.crt
+  update-ca-trust
+  mkdir -p /etc/dracut.conf.d/
+  cat << 'EOF' > /etc/dracut.conf.d/clevis-tls.conf
+install_items+=" /etc/pki/tls/certs/ca-bundle.crt "
+EOF
   if [ -z "${skip}" ]; then
     # Download advertisement.
-    curl -sfg http://"${TANG_SERVER}"/adv -o adv.jws
+    curl -sfg https://"${TANG_SERVER}"/adv -o adv.jws
     # Bind all LUKS devices
     max_attempts=10
     for dev in $(blkid -t TYPE=crypto_LUKS -o device); do
@@ -33,7 +39,7 @@ echo "#######################"
       # too low for settings" - loop until the binding succeeds or 10 times
       # per device.
       # https://access.redhat.com/solutions/3486131
-      until clevis luks bind -f -d "${dev}" sss '{"t":2,"pins":{"tang":[{"url":"http://'"${TANG_SERVER}"'","adv":"adv.jws"}], "tpm2": {"pcr_bank":"sha256", "pcr_ids":"0,7"}}}' <<< '@LUKS_PW@'; do
+      until clevis luks bind -f -d "${dev}" sss '{"t":2,"pins":{"tang":[{"url":"https://'"${TANG_SERVER}"'","adv":"adv.jws"}], "tpm2": {"pcr_bank":"sha256", "pcr_ids":"0,7"}}}' <<< '@LUKS_PW@'; do
         attempts=$((attempts+1))
         [ "${attempts}" -ge "${max_attempts}" ] && break
         sleep 0.1
@@ -41,7 +47,6 @@ echo "#######################"
     done
     # Enable clevis-luks-askpass.
     systemctl enable clevis-luks-askpass.path ||:
-    mkdir -p /etc/dracut.conf.d/
     echo 'kernel_cmdline="rd.neednet=1"' > /etc/dracut.conf.d/10mt-ks-post-clevis.conf
     dracut -f --regenerate-all
   else

--- a/Other/clevis-boot-unlock-all-pins/main.fmf
+++ b/Other/clevis-boot-unlock-all-pins/main.fmf
@@ -7,6 +7,7 @@ require:
   - name: /Library/vm
     url: https://github.com/RedHat-SP-Security/clevis-tests
     type: library
+  - socat
 duration: 2h
 enabled: true
 tag:
@@ -20,3 +21,17 @@ adjust:
   - enabled: false
     when: arch != x86_64
     continue: false
+/ecdsa:
+    environment:
+        CRYPTO_ALG: ECDSA
+/rsa:
+    environment:
+        CRYPTO_ALG: RSA
+/pqc_alg:
+    environment:
+        CRYPTO_ALG: ML-DSA-65
+    continue: false
+    adjust+:
+      - enabled: false
+        when: distro < rhel-10.1 or distro < fedora-43
+        because: PQC is available from this version of OS

--- a/Sanity/tang-pin-TLS/runtest.sh
+++ b/Sanity/tang-pin-TLS/runtest.sh
@@ -67,11 +67,11 @@ rlJournalStart
             rlRun "mkdir -p tangd/db tangd/cache"
             gen_tang_keys "tangd/db"
             gen_tang_cache "tangd/db" "tangd/cache"
-            port=$(start_tang_utils "tangd/cache")
+            port=$(start_tang_fn "tangd/cache")
         else
             rlRun "mkdir -p tangd/db"
             gen_tang_keys "tangd/db"
-            port=$(start_tang_utils "tangd/db")
+            port=$(start_tang_fn "tangd/db")
         fi
     rlPhaseEnd
 
@@ -104,7 +104,7 @@ CLEVIS_END
     rlPhaseEnd
 
     rlPhaseStartCleanup
-        stop_tang_utils "$port"
+        stop_tang_fn "$port"
         rlRun "popd"
         untrust_cert
         rlRun "rm -r $TmpDir" 0 "Removing tmp directory"


### PR DESCRIPTION
Clevis now should get keys from verified
tang via https, also adjust naming of helper tang functions.

## Summary by Sourcery

Enable TLS communication with the Tang server in the clevis-boot-unlock-all-pins scenario by generating and using certificates, updating helper functions, and adjusting test scripts to verify HTTPS connectivity.

Enhancements:
- Switch clevis-boot-unlock-all-pins scenario to HTTPS by generating TLS certificates and keys for Tang
- Rename start_tang_utils/stop_tang_utils to start_tang_fn/stop_tang_fn and update helper script accordingly
- Update runtest scripts to generate JWKs, launch Tang on a dynamic port, and verify TLS connectivity via curl
- Pass the TLS-enabled TANG_SERVER address and certificate path to the 10mt VM provisioning command

Tests:
- Adapt the Sanity tang-pin-TLS test to use the new start_tang_fn/stop_tang_fn functions for TLS-enabled Tang