### PR TITLE
Add clevis file ownership test

### DIFF
--- a/Sanity/clevis-files-ownership/main.fmf
+++ b/Sanity/clevis-files-ownership/main.fmf
@@ -1,0 +1,20 @@
+summary: verify correct file ownership
+description: verifies if important clevis files have correct ownership
+contact: Patrik Koncity <pkoncity@redhat.com>
+component:
+- tang
+test: ./runtest.sh
+framework: beakerlib
+recommend:
+- clevis
+- clevis-pin-tpm2
+duration: 5m
+enabled: true
+tag:
+- CI-Tier-1
+- Tier1
+tier: '1'
+adjust:
+-   enabled: false
+    when: distro == rhel-4, rhel-5, rhel-6, rhel-7, rhel-8
+    continue: false

--- a/Sanity/clevis-files-ownership/runtest.sh
+++ b/Sanity/clevis-files-ownership/runtest.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# vim: dict=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Author: Patrik Koncity <pkoncityt@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2025 Red Hat, Inc.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Include Beaker environment
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+TESTDIR=`pwd`
+
+function checkFile() {
+    MUSTEXIST=false
+    if [ "$1" == "-e" ]; then
+        MUSTEXIST=true
+        shift
+    fi
+    FILEPATH=$1
+    OWNER=$2
+    GROUP=$3
+    if "$MUSTEXIST" || [ -e "$FILEPATH" ]; then
+        ls -ld $FILEPATH
+        rlRun "ls -ld $FILEPATH | grep -qE '$OWNER[ ]*$GROUP'"
+    fi
+}
+
+rlJournalStart
+    rlPhaseStartTest
+        # verify user account
+        rlRun -s "id clevis"
+        rlRun "grep -E 'groups=.*clevis' $rlRun_LOG"
+        rlRun "grep -E 'gid=.*clevis' $rlRun_LOG"
+        rlRun "grep -E 'uid=.*clevis.*tss' $rlRun_LOG"
+    rlPhaseEnd
+rlJournalPrintText
+rlJournalEnd


### PR DESCRIPTION
## Summary by Sourcery

Introduce a clevis-files-ownership sanity test using Beakerlib to validate file ownership and user account configuration

New Features:
- Add a new Beakerlib-based sanity test suite for clevis file ownership

Tests:
- Implement a checkFile helper to verify file existence and ownership
- Add test cases to validate the clevis user account’s UID, GID, and group membership

Chores:
- Add FMF metadata for the new clevis-files-ownership test