### PR TITLE
Add missing tmt-IDs and reformat fmf files

### DIFF
--- a/Library/vm/main.fmf
+++ b/Library/vm/main.fmf
@@ -1,5 +1,5 @@
 summary: vm
-description: 'provides helper shell functions for testing with VMs'
+description: provides helper shell functions for testing with VMs
 contact: Sergio Correia <scorreia@redhat.com>
 test: ./test.sh
 framework: beakerlib
@@ -8,6 +8,7 @@ recommend:
 duration: 10m
 enabled: true
 adjust:
--   enabled: false
+  - enabled: false
     when: distro == rhel-4, rhel-5, rhel-6, rhel-7
     continue: false
+id: 69bced54-2a0b-4633-9a1a-b9d6539ada26

--- a/Other/clevis-boot-unlock-all-pins-multihost/main.fmf
+++ b/Other/clevis-boot-unlock-all-pins-multihost/main.fmf
@@ -1,7 +1,6 @@
 summary: Multihost Clevis and Tang functionality test
 description: |
-  Test of clevis boot unlock via all possible pins (tang, tpm2) and using sss in Image Mode.
-
+    Test of clevis boot unlock via all possible pins (tang, tpm2) and using sss in Image Mode.
 contact: Adam Prikryl <aprikryl@redhat.com>
 test: ./runtest.sh
 require+:
@@ -21,5 +20,5 @@ adjust:
   - enabled: false
     when: distro < rhel-9
     continue: false
-
 duration: 2h
+id: 00d6f250-7d2a-4e1e-9314-bf634c707978

--- a/Other/clevis-boot-unlock-all-pins/main.fmf
+++ b/Other/clevis-boot-unlock-all-pins/main.fmf
@@ -1,4 +1,5 @@
-summary: Test of clevis boot unlock via all possible pins (tang, tpm2) and using sss.
+summary: Test of clevis boot unlock via all possible pins (tang, tpm2) and using
+    sss.
 contact: Patrik Koncity <pkoncity@redhat.com>
 test: ./runtest.sh
 require:
@@ -23,9 +24,11 @@ adjust:
 /ecdsa:
     environment:
         CRYPTO_ALG: ECDSA
+    id: 273793a4-0378-4552-b183-ead6252e1f98
 /rsa:
     environment:
         CRYPTO_ALG: RSA
+    id: 368fc544-21a6-444c-b956-433363d48b76
 /pqc_alg:
     environment:
         CRYPTO_ALG: ML-DSA-65
@@ -34,3 +37,4 @@ adjust:
       - enabled: false
         when: distro < rhel-10.1 or distro < fedora-43
         because: PQC is available from this version of OS
+    id: 8fcbde9b-5643-4b16-aa89-25b81d1a4ba4

--- a/Regression/bz1878892-unattended-reboots/main.fmf
+++ b/Regression/bz1878892-unattended-reboots/main.fmf
@@ -28,3 +28,4 @@ adjust:
 extra-nitrate: TC#0612660
 extra-summary: /CoreOS/clevis/Regression/bz1878892-unattended-reboots
 extra-task: /CoreOS/clevis/Regression/bz1878892-unattended-reboots
+id: be1c1b12-029a-480b-8749-2a152adc4bd4

--- a/Regression/generate-initramfs/main.fmf
+++ b/Regression/generate-initramfs/main.fmf
@@ -1,4 +1,5 @@
-summary: Do not break generating initramfs by 'dracut -f' when clevis-dracut is installed.
+summary: Do not break generating initramfs by 'dracut -f' when clevis-dracut is 
+    installed.
 test: ./runtest.sh
 recommend:
   - clevis-dracut
@@ -21,3 +22,4 @@ adjust:
   - enabled: false
     when: distro == rhel-4, rhel-5, rhel-6
     continue: false
+id: 877c71f6-f2a4-4d24-90e5-0f4921614880

--- a/Sanity/automate-clevis-luks-bind/main.fmf
+++ b/Sanity/automate-clevis-luks-bind/main.fmf
@@ -1,5 +1,5 @@
-summary: This test validates the newly added -y (assume-yes) parameter that helps
-    automate clevis luks bind
+summary: This test validates the newly added -y (assume-yes) parameter that 
+    helps automate clevis luks bind
 test: ./runtest.sh
 recommend:
   - clevis
@@ -28,3 +28,4 @@ adjust:
   - enabled: false
     when: distro == rhel-alt-7
     continue: false
+id: 36079645-a946-4aa4-badd-58c1ac456495

--- a/Sanity/bind-luks/main.fmf
+++ b/Sanity/bind-luks/main.fmf
@@ -38,3 +38,4 @@ adjust:
   - enabled: false
     when: distro == rhel-4, rhel-5, rhel-6
     continue: false
+id: 04616254-4d61-4902-ba74-994e3678328e

--- a/Sanity/clevis-files-ownership/main.fmf
+++ b/Sanity/clevis-files-ownership/main.fmf
@@ -2,19 +2,20 @@ summary: verify correct file ownership
 description: verifies if important clevis files have correct ownership
 contact: Patrik Koncity <pkoncity@redhat.com>
 component:
-- tang
+  - tang
 test: ./runtest.sh
 framework: beakerlib
 recommend:
-- clevis
-- clevis-pin-tpm2
+  - clevis
+  - clevis-pin-tpm2
 duration: 5m
 enabled: true
 tag:
-- CI-Tier-1
-- Tier1
+  - CI-Tier-1
+  - Tier1
 tier: '1'
 adjust:
--   enabled: false
+  - enabled: false
     when: distro == rhel-4, rhel-5, rhel-6, rhel-7, rhel-8
     continue: false
+id: 9c6eaf18-331f-4398-ac83-51a298d36de5

--- a/Sanity/luks-edit/main.fmf
+++ b/Sanity/luks-edit/main.fmf
@@ -29,3 +29,4 @@ adjust:
   - enabled: false
     when: distro == rhel-alt-7
     continue: false
+id: 5e95c566-e2c2-4be3-b943-0a01e689fb7c

--- a/Sanity/luks-list/main.fmf
+++ b/Sanity/luks-list/main.fmf
@@ -28,3 +28,4 @@ adjust:
   - enabled: false
     when: distro ~< rhel-8.2
     continue: false
+id: 1367a296-335d-47a3-9958-245fe78a3e3a

--- a/Sanity/luks-pass/main.fmf
+++ b/Sanity/luks-pass/main.fmf
@@ -1,5 +1,5 @@
-summary: Test the 'clevis luks pass' subcommand with the device and slot as a parameter
-    and check the passphrase used to bind that particular slot.
+summary: Test the 'clevis luks pass' subcommand with the device and slot as a 
+    parameter and check the passphrase used to bind that particular slot.
 test: ./runtest.sh
 recommend:
   - clevis
@@ -31,3 +31,4 @@ adjust:
   - enabled: false
     when: distro ~< rhel-8.2
     continue: false
+id: d79ad730-bb1b-4b3e-a1a5-c87dccce88d0

--- a/Sanity/pin-sss/main.fmf
+++ b/Sanity/pin-sss/main.fmf
@@ -31,3 +31,4 @@ adjust:
   - enabled: false
     when: distro == rhel-4, rhel-5, rhel-6
     continue: false
+id: 96820f55-c245-4f71-bd3c-2e5a7d9f2e62

--- a/Sanity/pin-tang/main.fmf
+++ b/Sanity/pin-tang/main.fmf
@@ -31,3 +31,4 @@ adjust:
   - enabled: false
     when: distro == rhel-4, rhel-5, rhel-6
     continue: false
+id: f4687544-5a4e-41db-8d70-72f108e6dcc3

--- a/Sanity/pkcs11/basic/main.fmf
+++ b/Sanity/pkcs11/basic/main.fmf
@@ -37,8 +37,8 @@ tag:
 tier: '1'
 extra-summary: /CoreOS/clevis/Sanity/pkcs11/basic
 extra-task: /CoreOS/clevis/Sanity/pkcs11/basic
-#extra-nitrate: TC#0XXXXX
 adjust:
   - enabled: false
     when: distro == rhel-4, rhel-5, rhel-6, rhel-7, rhel-8
     continue: false
+id: 335052c7-104e-4550-b835-8fb448dddcc0

--- a/Sanity/pkcs11/luks-tpm2/main.fmf
+++ b/Sanity/pkcs11/luks-tpm2/main.fmf
@@ -31,7 +31,6 @@ tag:
   - TierCandidatesFAIL
 extra-summary: /CoreOS/clevis/Sanity/pkcs11/luks
 extra-task: /CoreOS/clevis/Sanity/pkcs11/luks
-#extra-nitrate: TC#0XXXXX
 adjust:
   - enabled: false
     when: distro == rhel-4, rhel-5, rhel-6, rhel-7, rhel-8
@@ -39,3 +38,4 @@ adjust:
   - enabled: false
     when: hwtpm != true
     continue: false
+id: 5f0170e6-9889-434b-aeb3-bee27fcf83a7

--- a/Sanity/pkcs11/single-encrypted-disk/main.fmf
+++ b/Sanity/pkcs11/single-encrypted-disk/main.fmf
@@ -1,4 +1,5 @@
-summary: tests the clevis pkcs#11 luks functionality using a single encrypted disk
+summary: tests the clevis pkcs#11 luks functionality using a single encrypted 
+    disk
 component:
   - clevis
 test: ./runtest.sh
@@ -31,11 +32,12 @@ tag:
   - TierCandidatesFAIL
 extra-summary: /CoreOS/clevis/Sanity/pkcs11/single-encrypted-disk
 extra-task: /CoreOS/clevis/Sanity/pkcs11/single-encrypted-disk
-#extra-nitrate: TC#0XXXXX
 adjust:
   - enabled: false
     when: distro == rhel-4, rhel-5, rhel-6, rhel-7, rhel-8
     continue: false
   - when: kickstart_pkcs11 is not defined or kickstart_pkcs11 == false
     enabled: false
-    because: This tests works only with provisioned kickstart file in plan and minimal hardware reqs.
+    because: This tests works only with provisioned kickstart file in plan and 
+        minimal hardware reqs.
+id: 6330df52-a762-4675-8799-524292290a8a

--- a/Sanity/sha256-thp/main.fmf
+++ b/Sanity/sha256-thp/main.fmf
@@ -27,3 +27,4 @@ adjust:
 extra-nitrate: TC#0610417
 extra-summary: /CoreOS/clevis/Sanity/sha256-thp
 extra-task: /CoreOS/clevis/Sanity/sha256-thp
+id: 3ca9d831-b7a7-45fb-a23c-277ef4ac1c35

--- a/Sanity/simple-encrypt-pin-tang/main.fmf
+++ b/Sanity/simple-encrypt-pin-tang/main.fmf
@@ -23,3 +23,4 @@ adjust:
   - enabled: false
     when: distro < rhel-7
     continue: false
+id: 5813e19f-d465-4992-b37a-d6a474b3edbd

--- a/Sanity/tang-high-availability/main.fmf
+++ b/Sanity/tang-high-availability/main.fmf
@@ -30,3 +30,4 @@ adjust:
   - enabled: false
     when: distro == rhel-4, rhel-5, rhel-6
     continue: false
+id: f9ab688b-41e7-4e54-85d2-57df2dfc3373

--- a/Sanity/tang-pin-TLS/main.fmf
+++ b/Sanity/tang-pin-TLS/main.fmf
@@ -33,9 +33,11 @@ adjust:
 /ecdsa:
     environment:
         CRYPTO_ALG: ECDSA
+    id: ea690dbf-d31b-4f4b-b70b-90467d420850
 /rsa:
     environment:
         CRYPTO_ALG: RSA
+    id: cbfdd381-61e9-4174-90f3-46170f7a1511
 /pqc_alg:
     environment:
         CRYPTO_ALG: ML-DSA-65
@@ -44,3 +46,4 @@ adjust:
       - enabled: false
         when: distro < rhel-10.1 or distro < fedora-43
         because: PQC is available from this version of OS
+    id: 91217887-b3e2-42de-826b-dd674636a48f

--- a/Sanity/tang-pin-hybrid-TLS/main.fmf
+++ b/Sanity/tang-pin-hybrid-TLS/main.fmf
@@ -1,4 +1,5 @@
-summary: tests tang pin with a 3-way hybrid TLS setup using Nginx and a socat-wrapped tangd.
+summary: tests tang pin with a 3-way hybrid TLS setup using Nginx and a 
+    socat-wrapped tangd.
 component:
   - tang
   - clevis
@@ -26,4 +27,4 @@ adjust:
   - enabled: false
     when: distro < rhel-10.1 or distro < fedora-43
     because: PQC is available from this version of OS
-
+id: 0864b1eb-8fbd-4696-8022-16da3966aba8

--- a/Sanity/upstream-test-suite/main.fmf
+++ b/Sanity/upstream-test-suite/main.fmf
@@ -24,3 +24,4 @@ adjust:
   - enabled: false
     when: distro < rhel-8
     continue: false
+id: d223668b-ff18-426c-8f16-8f9a382bff81


### PR DESCRIPTION
## Summary by Sourcery

Add missing tmt-IDs to FMF metadata and apply consistent formatting across all FMF files.

Enhancements:
- Add missing "tmt-id" entries to FMF files in Library, Other, Regression, and Sanity directories
- Reformat FMF files for consistent style, ordering, and indentation