### PR TITLE
Update of Packit configuration to use latest distros

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -25,9 +25,9 @@ jobs:
     targets:
       fedora-40: {}
       centos-stream-9-x86_64:
-          distros: [RHEL-9.6.0-Nightly]
+          distros: [RHEL-9-Nightly]
       centos-stream-10-x86_64:
-          distros: [RHEL-10.0-Nightly]
+          distros: [RHEL-10-Nightly]
     tf_extra_params:
       test:
         tmt:


### PR DESCRIPTION
## Summary by Sourcery

Update Packit configuration to use generic nightly distro identifiers for RHEL 9 and RHEL 10

CI:
- Use RHEL-9-Nightly instead of RHEL-9.6.0-Nightly for centos-stream-9 builds
- Use RHEL-10-Nightly instead of RHEL-10.0-Nightly for centos-stream-10 builds