### PR TITLE
Sanity/luks-pass | Adjust the LUKS KDF parameter

### DIFF
--- a/Sanity/luks-pass/runtest.sh
+++ b/Sanity/luks-pass/runtest.sh
@@ -46,7 +46,7 @@ rlJournalStart
 
         rlRun "dd if=/dev/zero of=loopfile bs=100M count=1"
         rlRun "lodev=\$(losetup -f --show loopfile)" 0 "Create device from file"
-        rlRun "echo -n redhat123 | cryptsetup luksFormat --batch-mode --key-file - ${lodev}"
+        rlRun "echo -n redhat123 | cryptsetup luksFormat --batch-mode --key-file - --pbkdf-memory 65536 ${lodev}"
 
         rlRun "rlServiceStart tangd.socket"
     rlPhaseEnd


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Add `--pbkdf-memory 65536` to the `cryptsetup luksFormat` command in the runtest.sh script