### PR TITLE
Add fips tag to FIPS-relevant tests

### DIFF
--- a/Sanity/bind-luks/main.fmf
+++ b/Sanity/bind-luks/main.fmf
@@ -22,6 +22,7 @@ recommend:
 duration: 5m
 enabled: true
 tag:
+  - fips
   - CI-Tier-1
   - NoRHEL4
   - NoRHEL5

--- a/Sanity/kernel-keyring-support/main.fmf
+++ b/Sanity/kernel-keyring-support/main.fmf
@@ -6,6 +6,7 @@ enabled: true
 link:
   - verifies: https://bugzilla.redhat.com/show_bug.cgi?id=2126533
 tag:
+  - fips
   - CI-Tier-1
   - Tier1
 tier: '1'

--- a/Sanity/luks-edit/main.fmf
+++ b/Sanity/luks-edit/main.fmf
@@ -7,6 +7,7 @@ recommend:
 duration: 10m
 enabled: true
 tag:
+  - fips
   - CI-Tier-1
   - NoRHEL4
   - NoRHEL5

--- a/Sanity/luks-list/main.fmf
+++ b/Sanity/luks-list/main.fmf
@@ -8,6 +8,7 @@ recommend:
 duration: 5m
 enabled: true
 tag:
+  - fips
   - CI-Tier-1
   - NoRHEL4
   - NoRHEL5

--- a/Sanity/luks-pass/main.fmf
+++ b/Sanity/luks-pass/main.fmf
@@ -11,6 +11,7 @@ recommend:
 duration: 5m
 enabled: true
 tag:
+  - fips
   - CI-Tier-1
   - NoRHEL4
   - NoRHEL5

--- a/Sanity/password-generation/main.fmf
+++ b/Sanity/password-generation/main.fmf
@@ -6,6 +6,7 @@ recommend:
   - tang
 duration: 10m
 tag:
+  - fips
   - Tier3
 link:
   - verifies: https://bugzilla.redhat.com/show_bug.cgi?id=2207488

--- a/Sanity/pin-sss/main.fmf
+++ b/Sanity/pin-sss/main.fmf
@@ -14,6 +14,7 @@ recommend:
 duration: 5m
 enabled: true
 tag:
+  - fips
   - CI-Tier-1
   - NoRHEL4
   - NoRHEL5

--- a/Sanity/pin-tang/main.fmf
+++ b/Sanity/pin-tang/main.fmf
@@ -14,6 +14,7 @@ recommend:
 duration: 5m
 enabled: true
 tag:
+  - fips
   - CI-Tier-1
   - NoRHEL4
   - NoRHEL5

--- a/Sanity/pkcs11/basic/main.fmf
+++ b/Sanity/pkcs11/basic/main.fmf
@@ -23,6 +23,7 @@ recommend:
 duration: 10m
 enabled: true
 tag:
+  - fips
   - CI-Tier-1
   - NoRHEL4
   - NoRHEL5

--- a/Sanity/sha256-thp/main.fmf
+++ b/Sanity/sha256-thp/main.fmf
@@ -6,6 +6,7 @@ recommend:
 duration: 10m
 enabled: true
 tag:
+  - fips
   - NoRHEL6
   - NoRHEL7
   - Tier1

--- a/Sanity/simple-bind-luks/main.fmf
+++ b/Sanity/simple-bind-luks/main.fmf
@@ -7,6 +7,7 @@ recommend:
 duration: 5m
 enabled: true
 tag:
+  - fips
   - NoRHEL4
   - NoRHEL5
   - SP-TBU

--- a/Sanity/simple-encrypt-pin-tang/main.fmf
+++ b/Sanity/simple-encrypt-pin-tang/main.fmf
@@ -7,6 +7,7 @@ recommend:
 duration: 5m
 enabled: true
 tag:
+  - fips
   - CI-Tier-1
   - NoRHEL4
   - NoRHEL5

--- a/Sanity/tang-pin-TLS/main.fmf
+++ b/Sanity/tang-pin-TLS/main.fmf
@@ -16,6 +16,7 @@ recommend:
 duration: 5m
 enabled: true
 tag:
+  - fips
   - CI-Tier-1
   - NoRHEL4
   - NoRHEL5

--- a/Sanity/tang-pin-hybrid-TLS/main.fmf
+++ b/Sanity/tang-pin-hybrid-TLS/main.fmf
@@ -18,6 +18,7 @@ recommend:
 duration: 10m
 enabled: true
 tag:
+  - fips
   - NoRHEL4
   - NoRHEL5
   - NoRHEL6


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Mark multiple LUKS, PKCS#11, keyring, and Tang-related sanity tests with a FIPS tag to enable targeted execution in FIPS environments.