### PR TITLE
Fix multihost sync deadlock on mixed-architecture combinations

### DIFF
--- a/Other/clevis-boot-unlock-all-pins-multihost/runtest.sh
+++ b/Other/clevis-boot-unlock-all-pins-multihost/runtest.sh
@@ -49,7 +49,7 @@ function get_IP() {
         if [ -n "$ipv4" ]; then
             echo "$ipv4"
         else
-            getent hosts "$1" | awk '{ print $1 }' | head -n 1
+            getent hosts "$1" | awk '$1 ~ /^[0-9]+\./ { print $1; exit }'
         fi
     fi
 }
@@ -75,10 +75,13 @@ function assign_roles() {
         export TANG=$( echo "$SERVERS $CLIENTS" | awk '{ print $2 }')
     fi
     [ -z "$MY_IP" ] && MY_IP=$( hostname -I | tr ' ' '\n' | grep -E '^[0-9]+\.' | head -n 1 )
+    if [ -z "$MY_IP" ]; then
+        rlFail "No IPv4 address found for this host (hostname -I returned only IPv6). Sync library requires IPv4."
+    fi
     [ -n "$CLEVIS" ] && export CLEVIS_IP=$( get_IP "$CLEVIS" )
     [ -n "$TANG" ] && export TANG_IP=$( get_IP "$TANG" )
     if [ -z "$CLEVIS_IP" ] || [ -z "$TANG_IP" ]; then
-        rlFail "Could not resolve client or server IP addresses."
+        rlFail "Could not resolve IPv4 address for client or server. Sync library requires IPv4."
     fi
     rlLog "ROLE ASSIGNMENT:"
     rlLog "Client Host: ${CLEVIS} (${CLEVIS_IP})"

--- a/Other/clevis-boot-unlock-all-pins-multihost/runtest.sh
+++ b/Other/clevis-boot-unlock-all-pins-multihost/runtest.sh
@@ -41,7 +41,16 @@ function get_IP() {
     if echo "$1" | grep -E -q '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'; then
         echo "$1"
     else
-        getent hosts "$1" | awk '{ print $1 }' | head -n 1
+        # Prefer IPv4 — the sync library's sync-get service (ncat -l)
+        # only listens on IPv4, so IPv6 addresses cause sync-block to
+        # fail silently and deadlock the multihost test.
+        local ipv4
+        ipv4=$(getent ahostsv4 "$1" 2>/dev/null | awk 'NR==1{ print $1 }')
+        if [ -n "$ipv4" ]; then
+            echo "$ipv4"
+        else
+            getent hosts "$1" | awk '{ print $1 }' | head -n 1
+        fi
     fi
 }
 
@@ -65,7 +74,7 @@ function assign_roles() {
         export CLEVIS=$( echo "$SERVERS $CLIENTS" | awk '{ print $1 }')
         export TANG=$( echo "$SERVERS $CLIENTS" | awk '{ print $2 }')
     fi
-    [ -z "$MY_IP" ] && MY_IP=$( hostname -I | awk '{ print $1 }' )
+    [ -z "$MY_IP" ] && MY_IP=$( hostname -I | tr ' ' '\n' | grep -E '^[0-9]+\.' | head -n 1 )
     [ -n "$CLEVIS" ] && export CLEVIS_IP=$( get_IP "$CLEVIS" )
     [ -n "$TANG" ] && export TANG_IP=$( get_IP "$TANG" )
     if [ -z "$CLEVIS_IP" ] || [ -z "$TANG_IP" ]; then


### PR DESCRIPTION
The sync library's sync-get service (ncat -l) only listens on IPv4. When get_IP() resolved a hostname to an IPv6 address, sync-block tried to connect via IPv6, the connection silently failed every round, and the multihost test deadlocked until the 2-hour duration limit.

Prefer IPv4 in get_IP() via getent ahostsv4, falling back to getent hosts only when no IPv4 address exists. Also filter hostname -I output for MY_IP to avoid picking up an IPv6 address.

## Summary by Sourcery

Ensure multihost clevis boot unlock tests consistently use IPv4 addresses to avoid sync deadlocks on hosts with IPv6.

Bug Fixes:
- Prevent multihost sync deadlocks by preferring IPv4 resolution for hostnames used by the sync library.
- Avoid selecting IPv6 addresses for the local host IP when assigning multihost test roles.