### PR TITLE
Add missing descriptions to main.fmf test cases

### DIFF
--- a/Other/clevis-boot-unlock-all-pins/main.fmf
+++ b/Other/clevis-boot-unlock-all-pins/main.fmf
@@ -1,5 +1,8 @@
 summary: Test of clevis boot unlock via all possible pins (tang, tpm2) and using
     sss.
+description: |
+    Verify that a VM with a LUKS-encrypted disk can be automatically unlocked
+    during early boot using clevis with tang (over TLS) and sss pins.
 contact: Patrik Koncity <pkoncity@redhat.com>
 test: ./runtest.sh
 require:

--- a/Regression/bz1878892-unattended-reboots/main.fmf
+++ b/Regression/bz1878892-unattended-reboots/main.fmf
@@ -1,4 +1,7 @@
 summary: Tests that the system unlocks a non-root device in early boot
+description: |
+    Verify that a LUKS-encrypted non-root device bound to a tang server via
+    clevis is automatically unlocked across multiple unattended VM reboots.
 test: ./runtest.sh
 recommend:
   - awk

--- a/Regression/generate-initramfs/main.fmf
+++ b/Regression/generate-initramfs/main.fmf
@@ -1,5 +1,8 @@
-summary: Do not break generating initramfs by 'dracut -f' when clevis-dracut is 
+summary: Do not break generating initramfs by 'dracut -f' when clevis-dracut is
     installed.
+description: |
+    Verify that regenerating the initramfs with 'dracut -f' succeeds when
+    clevis-dracut is installed and that clevis modules are included in the image.
 test: ./runtest.sh
 recommend:
   - clevis-dracut

--- a/Sanity/automate-clevis-luks-bind/main.fmf
+++ b/Sanity/automate-clevis-luks-bind/main.fmf
@@ -1,5 +1,9 @@
-summary: This test validates the newly added -y (assume-yes) parameter that 
+summary: This test validates the newly added -y (assume-yes) parameter that
     helps automate clevis luks bind
+description: |
+    Verify that the -y (assume-yes) parameter allows non-interactive clevis luks
+    bind, unlock, and unbind operations on both LUKS1 and LUKS2 devices using
+    tang and sss pins.
 test: ./runtest.sh
 recommend:
   - clevis

--- a/Sanity/luks-edit/main.fmf
+++ b/Sanity/luks-edit/main.fmf
@@ -1,4 +1,8 @@
 summary: Tests for the clevis luks edit command
+description: |
+    Verify that 'clevis luks edit' correctly handles tang and sss pin
+    configuration changes on LUKS1 and LUKS2 devices, including URL updates,
+    threshold modifications, and rejection of invalid or unchanged configs.
 test: ./runtest.sh
 recommend:
   - clevis

--- a/Sanity/luks-list/main.fmf
+++ b/Sanity/luks-list/main.fmf
@@ -1,4 +1,8 @@
 summary: Sanity check for listing PBD policies and check proper failing message
+description: |
+    Verify that 'clevis luks list' correctly displays bound PBD policies, that
+    'clevis luks bind' produces proper error messages for invalid pins and
+    missing configurations, and that bind/unlock operations work with tang.
 test: ./runtest.sh
 recommend:
   - clevis

--- a/Sanity/luks-pass/main.fmf
+++ b/Sanity/luks-pass/main.fmf
@@ -1,5 +1,9 @@
-summary: Test the 'clevis luks pass' subcommand with the device and slot as a 
+summary: Test the 'clevis luks pass' subcommand with the device and slot as a
     parameter and check the passphrase used to bind that particular slot.
+description: |
+    Verify that 'clevis luks pass' extracts the correct passphrase for a
+    tang-bound LUKS slot and that the extracted passphrase can be used to
+    manually open the encrypted volume with cryptsetup.
 test: ./runtest.sh
 recommend:
   - clevis

--- a/Sanity/password-generation/main.fmf
+++ b/Sanity/password-generation/main.fmf
@@ -1,4 +1,8 @@
 summary: Generating password during clevis binding does not fail on low entropy
+description: |
+    Verify that clevis luks bind with a tang pin succeeds multiple times under
+    restrictive pwquality settings (maxclassrepeat), ensuring password generation
+    does not fail on low entropy.
 test: ./test.sh
 recommend:
   - clevis

--- a/Sanity/pin-sss/main.fmf
+++ b/Sanity/pin-sss/main.fmf
@@ -1,4 +1,8 @@
 summary: tests the sss pin functionality of clevis
+description: |
+    Verify that clevis sss pin correctly encrypts and decrypts data using a
+    threshold (t=2) of three tang servers, including scenarios where all, none,
+    one, or two servers are available.
 component:
   - tang
   - clevis

--- a/Sanity/pin-tang/main.fmf
+++ b/Sanity/pin-tang/main.fmf
@@ -1,4 +1,8 @@
 summary: tests the tang pin functionality of clevis
+description: |
+    Verify that clevis tang pin encrypts and decrypts data correctly using
+    interactive trust confirmation, known thumbprints, and pre-fetched
+    advertisement files.
 component:
   - tang
   - clevis

--- a/Sanity/pkcs11/basic/main.fmf
+++ b/Sanity/pkcs11/basic/main.fmf
@@ -1,4 +1,7 @@
 summary: tests the basic pkcs#11 functionality of clevis
+description: |
+    Verify that clevis pkcs11 pin encrypts and decrypts data using a SoftHSM
+    token, and that decryption correctly fails when the token is removed.
 component:
   - clevis
 test: ./runtest.sh

--- a/Sanity/pkcs11/luks-tpm2/main.fmf
+++ b/Sanity/pkcs11/luks-tpm2/main.fmf
@@ -1,4 +1,8 @@
 summary: tests the basic pkcs#11 luks and tpm2 functionality of clevis
+description: |
+    Verify that clevis LUKS binding and unlocking works with pkcs11 and tpm2 pins
+    combined via sss, including single-factor and two-factor threshold scenarios,
+    and that operations fail when the PKCS#11 token is removed.
 component:
   - clevis
 test: ./runtest.sh

--- a/Sanity/pkcs11/single-encrypted-disk/main.fmf
+++ b/Sanity/pkcs11/single-encrypted-disk/main.fmf
@@ -1,5 +1,9 @@
-summary: tests the clevis pkcs#11 luks functionality using a single encrypted 
+summary: tests the clevis pkcs#11 luks functionality using a single encrypted
     disk
+description: |
+    Verify that a LUKS-encrypted secondary disk bound with clevis pkcs11 pin
+    using a SoftHSM token is automatically unlocked by clevis during system boot
+    after a reboot.
 component:
   - clevis
 test: ./runtest.sh

--- a/Sanity/sha256-thp/main.fmf
+++ b/Sanity/sha256-thp/main.fmf
@@ -1,4 +1,8 @@
 summary: Test clevis SHA-256 thumbprints
+description: |
+    Verify that clevis supports both SHA-1 and SHA-256 tang thumbprints for
+    encryption and decryption, can decrypt legacy SHA-1 encoded data, and uses
+    SHA-256 thumbprints for newly encrypted data on RHEL 9+.
 test: ./runtest.sh
 recommend:
   - clevis

--- a/Sanity/simple-bind-luks/main.fmf
+++ b/Sanity/simple-bind-luks/main.fmf
@@ -1,4 +1,8 @@
 summary: Simple version of 'clevis luks bind' test
+description: |
+    Verify that 'clevis luks bind' with a tang pin correctly binds a LUKS device,
+    'clevis luks unlock' successfully unlocks it, and that unlock fails when the
+    tang server is unavailable.
 test: ./runtest.sh
 recommend:
   - clevis-luks

--- a/Sanity/simple-encrypt-pin-tang/main.fmf
+++ b/Sanity/simple-encrypt-pin-tang/main.fmf
@@ -1,4 +1,8 @@
 summary: Simple way how to test 'clevis encrypt tang'
+description: |
+    Verify that 'clevis encrypt tang' encrypts a plaintext file using a
+    pre-fetched tang advertisement and that 'clevis decrypt' restores the
+    original content.
 test: ./runtest.sh
 recommend:
   - clevis

--- a/Sanity/tang-high-availability/main.fmf
+++ b/Sanity/tang-high-availability/main.fmf
@@ -1,4 +1,8 @@
 summary: verifies sharing keys between tang servers
+description: |
+    Verify that data encrypted against one tang server can be decrypted by
+    a second tang server sharing the same key material, ensuring high
+    availability of the tang service.
 component:
   - tang
   - clevis

--- a/Sanity/tang-pin-TLS/main.fmf
+++ b/Sanity/tang-pin-TLS/main.fmf
@@ -1,4 +1,8 @@
 summary: tests the tang pin functionality of clevis with TLS connection
+description: |
+    Verify that clevis tang pin correctly encrypts and decrypts data over a TLS
+    connection using configurable certificate algorithms (RSA, ECDSA, ML-DSA-65),
+    with both interactive trust confirmation and known thumbprint methods.
 component:
   - tang
   - clevis

--- a/Sanity/tang-pin-hybrid-TLS/main.fmf
+++ b/Sanity/tang-pin-hybrid-TLS/main.fmf
@@ -1,5 +1,9 @@
-summary: tests tang pin with a 3-way hybrid TLS setup using Nginx and a 
+summary: tests tang pin with a 3-way hybrid TLS setup using Nginx and a
     socat-wrapped tangd.
+description: |
+    Verify that clevis tang pin works over HTTPS with a 3-way hybrid TLS
+    configuration (ECDSA, RSA, ML-DSA-65 certificates) using Nginx as a reverse
+    proxy, including interactive trust and thumbprint-based encryption.
 component:
   - tang
   - clevis

--- a/Sanity/upstream-test-suite/main.fmf
+++ b/Sanity/upstream-test-suite/main.fmf
@@ -1,4 +1,7 @@
 summary: Run the upstream test suite
+description: |
+    Verify that the clevis upstream test suite passes by building the project
+    from its source RPM, applying downstream patches, and running meson test.
 contact: Martin Zelený <mzeleny@redhat.com>
 test: ./runtest.sh
 recommend:


### PR DESCRIPTION
Add descriptions to test cases that had empty or missing description field in main.fmf.

## Summary by Sourcery

Tests:
- Update FMF metadata for various sanity, regression, and other test cases by populating previously empty or missing description fields.