### PR TITLE
Add FIPS mode handling for pkcs11, tang-pin-TLS, and hybrid-TLS tests

### DIFF
--- a/Sanity/pkcs11/basic/runtest.sh
+++ b/Sanity/pkcs11/basic/runtest.sh
@@ -36,28 +36,41 @@ rlJournalStart
     rlPhaseStartSetup
         # Include utils library containing critical functions
         rlRun ". ../../../TestHelpers/utils.sh" || rlDie "cannot import function script"
-        install_clevis_pkcs11
-        rlRun "rpm -q $PACKAGE || which clevis" 0 "Checking for the presence of clevis rpm"
-        rlRun "TMPDIR=\$(mktemp -d)" 0 "Creating tmp directory"
-        rlRun "pushd $TMPDIR"
 
-        if packageVersion=$(rpm -q ${PACKAGE} --qf '%{name}-%{version}-%{release}\n' 2>/dev/null); then
-            rlTestVersion "${packageVersion}" '>=' 'clevis-20-2'
+        # RSA-PKCS (PKCS#1 v1.5) padding is not allowed in FIPS mode
+        # and SoftHSM does not support RSA-PKCS-OAEP
+        if is_fips_enabled; then
+            FIPS_MODE=true
+            rlLog "FIPS mode detected: RSA-PKCS mechanism is not FIPS-compliant, skipping test"
+        else
+            FIPS_MODE=false
         fi
 
-        install_softhsm
+        if ! $FIPS_MODE; then
+            install_clevis_pkcs11
+            rlRun "rpm -q $PACKAGE || which clevis" 0 "Checking for the presence of clevis rpm"
+            rlRun "TMPDIR=\$(mktemp -d)" 0 "Creating tmp directory"
+            rlRun "pushd $TMPDIR"
 
-        create_hsm_config
+            if packageVersion=$(rpm -q ${PACKAGE} --qf '%{name}-%{version}-%{release}\n' 2>/dev/null); then
+                rlTestVersion "${packageVersion}" '>=' 'clevis-20-2'
+            fi
 
-        export SOFTHSM2_CONF=$TMPDIR/softhsm.conf
-        create_token
+            install_softhsm
 
-        # Get serial number of the token
-        TOKEN_SERIAL_NUM=$(pkcs11-tool --module $SOFTHSM_LIB -L | grep "serial num" | awk '{print $4}')
-        rlAssertNotEquals "Test that the serial number is not empty" "" $TOKEN_SERIAL_NUM
-        URI="{\"uri\": \"pkcs11:model=SoftHSM%20v2;manufacturer=SoftHSM%20project;serial=$TOKEN_SERIAL_NUM;token=$TOKEN_LABEL;id=$ID;module-path=$SOFTHSM_LIB?pin-value=$PINVALUE\", \"mechanism\": \"RSA-PKCS\"}"
+            create_hsm_config
+
+            export SOFTHSM2_CONF=$TMPDIR/softhsm.conf
+            create_token
+
+            # Get serial number of the token
+            TOKEN_SERIAL_NUM=$(pkcs11-tool --module $SOFTHSM_LIB -L | grep "serial num" | awk '{print $4}')
+            rlAssertNotEquals "Test that the serial number is not empty" "" $TOKEN_SERIAL_NUM
+            URI="{\"uri\": \"pkcs11:model=SoftHSM%20v2;manufacturer=SoftHSM%20project;serial=$TOKEN_SERIAL_NUM;token=$TOKEN_LABEL;id=$ID;module-path=$SOFTHSM_LIB?pin-value=$PINVALUE\", \"mechanism\": \"RSA-PKCS\"}"
+        fi
     rlPhaseEnd
 
+  if ! $FIPS_MODE; then
     rlPhaseStart FAIL "clevis pkcs11 - Simple text encryption and decryption"
         rlRun "echo 'this is a secret 1' > plain_text" 0 "Create a file to encrypt"
         rlRun "clevis encrypt pkcs11 '$URI' < plain_text > JWE" 0 "Encrypting the plain text"
@@ -132,10 +145,14 @@ rlJournalStart
         rlRun "rm plain_text JWE"
     rlPhaseEnd
 
+  fi # ! $FIPS_MODE
+
     rlPhaseStartCleanup
-        rlRun "softhsm2-util --delete-token --token $TOKEN_LABEL" 0,1
-        rlRun "popd"
-        rlRun "rm -r $TMPDIR" 0 "Removing tmp directory"
+        if ! $FIPS_MODE; then
+            rlRun "softhsm2-util --delete-token --token $TOKEN_LABEL" 0,1
+            rlRun "popd"
+            rlRun "rm -r $TMPDIR" 0 "Removing tmp directory"
+        fi
     rlPhaseEnd
 rlJournalPrintText
 rlJournalEnd

--- a/Sanity/pkcs11/basic/runtest.sh
+++ b/Sanity/pkcs11/basic/runtest.sh
@@ -46,7 +46,7 @@ rlJournalStart
             FIPS_MODE=false
         fi
 
-        if ! $FIPS_MODE; then
+        if [ "$FIPS_MODE" != true ]; then
             install_clevis_pkcs11
             rlRun "rpm -q $PACKAGE || which clevis" 0 "Checking for the presence of clevis rpm"
             rlRun "TMPDIR=\$(mktemp -d)" 0 "Creating tmp directory"
@@ -70,7 +70,7 @@ rlJournalStart
         fi
     rlPhaseEnd
 
-  if ! $FIPS_MODE; then
+  if [ "$FIPS_MODE" != true ]; then
     rlPhaseStart FAIL "clevis pkcs11 - Simple text encryption and decryption"
         rlRun "echo 'this is a secret 1' > plain_text" 0 "Create a file to encrypt"
         rlRun "clevis encrypt pkcs11 '$URI' < plain_text > JWE" 0 "Encrypting the plain text"
@@ -145,10 +145,10 @@ rlJournalStart
         rlRun "rm plain_text JWE"
     rlPhaseEnd
 
-  fi # ! $FIPS_MODE
+  fi # FIPS_MODE
 
     rlPhaseStartCleanup
-        if ! $FIPS_MODE; then
+        if [ "$FIPS_MODE" != true ]; then
             rlRun "softhsm2-util --delete-token --token $TOKEN_LABEL" 0,1
             rlRun "popd"
             rlRun "rm -r $TMPDIR" 0 "Removing tmp directory"

--- a/Sanity/tang-pin-TLS/runtest.sh
+++ b/Sanity/tang-pin-TLS/runtest.sh
@@ -49,17 +49,28 @@ untrust_cert() {
 
 PACKAGE="clevis"
 
+SKIP_TEST=false
+
 rlJournalStart
     rlPhaseStartSetup
         rlRun ". ../../TestHelpers/utils.sh" || rlDie "cannot import function script"
         rlLog "TLS Certificate Algorithm: $CRYPTO_ALG"
         rlLog "TLS is ENABLED for this run."
-        rlRun "TmpDir=\$(mktemp -d)" 0 "Creating tmp directory"
-        rlRun "pushd $TmpDir"
-        rlRun "gen_tls_cert ${CRYPTO_ALG} 'server.key' 'server.crt'"
-        trust_cert
+
+        if is_fips_enabled && [ "$CRYPTO_ALG" = "ML-DSA-65" ]; then
+            rlLog "FIPS mode detected: ML-DSA-65 (post-quantum) is not available in FIPS mode, skipping test"
+            SKIP_TEST=true
+        fi
+
+        if ! $SKIP_TEST; then
+            rlRun "TmpDir=\$(mktemp -d)" 0 "Creating tmp directory"
+            rlRun "pushd $TmpDir"
+            rlRun "gen_tls_cert ${CRYPTO_ALG} 'server.key' 'server.crt'"
+            trust_cert
+        fi
     rlPhaseEnd
 
+  if ! $SKIP_TEST; then
     rlPhaseStart FAIL "tangd setup"
         # NOTE: This 'legacy_tang' check is from an old script version and will likely fail.
         # It's better to remove this if/else block if you only support modern tang.
@@ -103,11 +114,15 @@ CLEVIS_END
         rm -f adv plain enc plain2
     rlPhaseEnd
 
+  fi # ! $SKIP_TEST
+
     rlPhaseStartCleanup
-        stop_tang_fn "$port"
-        rlRun "popd"
-        untrust_cert
-        rlRun "rm -r $TmpDir" 0 "Removing tmp directory"
+        if ! $SKIP_TEST; then
+            stop_tang_fn "$port"
+            rlRun "popd"
+            untrust_cert
+            rlRun "rm -r $TmpDir" 0 "Removing tmp directory"
+        fi
     rlPhaseEnd
 rlJournalPrintText
 rlJournalEnd

--- a/Sanity/tang-pin-TLS/runtest.sh
+++ b/Sanity/tang-pin-TLS/runtest.sh
@@ -62,7 +62,7 @@ rlJournalStart
             SKIP_TEST=true
         fi
 
-        if ! $SKIP_TEST; then
+        if [ "$SKIP_TEST" != true ]; then
             rlRun "TmpDir=\$(mktemp -d)" 0 "Creating tmp directory"
             rlRun "pushd $TmpDir"
             rlRun "gen_tls_cert ${CRYPTO_ALG} 'server.key' 'server.crt'"
@@ -70,7 +70,7 @@ rlJournalStart
         fi
     rlPhaseEnd
 
-  if ! $SKIP_TEST; then
+  if [ "$SKIP_TEST" != true ]; then
     rlPhaseStart FAIL "tangd setup"
         # NOTE: This 'legacy_tang' check is from an old script version and will likely fail.
         # It's better to remove this if/else block if you only support modern tang.
@@ -114,10 +114,10 @@ CLEVIS_END
         rm -f adv plain enc plain2
     rlPhaseEnd
 
-  fi # ! $SKIP_TEST
+  fi # SKIP_TEST
 
     rlPhaseStartCleanup
-        if ! $SKIP_TEST; then
+        if [ "$SKIP_TEST" != true ]; then
             stop_tang_fn "$port"
             rlRun "popd"
             untrust_cert

--- a/Sanity/tang-pin-hybrid-TLS/runtest.sh
+++ b/Sanity/tang-pin-hybrid-TLS/runtest.sh
@@ -26,10 +26,10 @@ grep_b64() {
             jose b64 dec -i "$2" -O -
 }
 
-# Copies ALL server certificates to the system trust store.
+# Copies server certificates to the system trust store.
 trust_certs() {
     rlRun "cp server_ecdsa.crt /etc/pki/ca-trust/source/anchors/temp-tang-ecdsa-$$.crt"
-    rlRun "cp server_mldsa.crt /etc/pki/ca-trust/source/anchors/temp-tang-mldsa-$$.crt"
+    [ -f server_mldsa.crt ] && rlRun "cp server_mldsa.crt /etc/pki/ca-trust/source/anchors/temp-tang-mldsa-$$.crt"
     rlRun "cp server_rsa.crt /etc/pki/ca-trust/source/anchors/temp-tang-rsa-$$.crt"
     rlRun "update-ca-trust"
 }
@@ -47,9 +47,15 @@ rlJournalStart
         rlRun ". ../../TestHelpers/utils.sh" || rlDie "cannot import function script"
         rlRun "TmpDir=\$(mktemp -d)" 0 "Creating tmp directory"
         rlRun "pushd $TmpDir"
-        # Generate all three types of TLS certificates using the function from utils.sh
+        # Generate TLS certificates
         rlRun "gen_tls_cert 'ECDSA' 'server_ecdsa.key' 'server_ecdsa.crt'"
-        rlRun "gen_tls_cert 'ML-DSA-65' 'server_mldsa.key' 'server_mldsa.crt'"
+        if is_fips_enabled; then
+            MLDSA_AVAILABLE=false
+            rlLog "FIPS mode detected: skipping ML-DSA-65 certificate (not available in FIPS mode)"
+        else
+            rlRun "gen_tls_cert 'ML-DSA-65' 'server_mldsa.key' 'server_mldsa.crt'"
+            MLDSA_AVAILABLE=true
+        fi
         rlRun "gen_tls_cert 'RSA' 'server_rsa.key' 'server_rsa.crt'"
         trust_certs
         # Prepare and start Tang server
@@ -75,8 +81,13 @@ rlJournalStart
             fi
         done
         [ -n "$https_port" ] || { rlLogFatal "No free port for Nginx"; rlDie; }
+        MLDSA_SSL_LINES=""
+        if $MLDSA_AVAILABLE; then
+            MLDSA_SSL_LINES="    ssl_certificate     $(pwd)/server_mldsa.crt;
+    ssl_certificate_key $(pwd)/server_mldsa.key;"
+        fi
         cat > nginx.conf <<EOF
-# Managed by BeakerLib test for 3-way HYBRID TLS
+# Managed by BeakerLib test for HYBRID TLS
 pid $(pwd)/nginx.pid;
 error_log $(pwd)/nginx.error.log;
 events { worker_connections 1024; }
@@ -85,8 +96,7 @@ http { server {
     server_name localhost;
     ssl_certificate     $(pwd)/server_ecdsa.crt;
     ssl_certificate_key $(pwd)/server_ecdsa.key;
-    ssl_certificate     $(pwd)/server_mldsa.crt;
-    ssl_certificate_key $(pwd)/server_mldsa.key;
+${MLDSA_SSL_LINES}
     ssl_certificate     $(pwd)/server_rsa.crt;
     ssl_certificate_key $(pwd)/server_rsa.key;
     location / { proxy_pass http://localhost:${tang_http_port}; }
@@ -141,10 +151,14 @@ CLEVIS_END
         rlRun "grep 'SSL connection using.*RSA' rsa_debug.log" \
             0 "Verify RSA cipher was used"
         # ML-DSA-65
-        rlRun "curl -v --cacert server_mldsa.crt  https://localhost:$https_port/adv/ 2> mldsa_debug.log" \
-            0 "Connect with ML-DSA signature algorithm"
-        rlRun "grep 'SSL connection using.*id-ml-dsa-65' mldsa_debug.log" \
-            0 "Verify MLDSA65 cipher was used"
+        if $MLDSA_AVAILABLE; then
+            rlRun "curl -v --cacert server_mldsa.crt  https://localhost:$https_port/adv/ 2> mldsa_debug.log" \
+                0 "Connect with ML-DSA signature algorithm"
+            rlRun "grep 'SSL connection using.*id-ml-dsa-65' mldsa_debug.log" \
+                0 "Verify MLDSA65 cipher was used"
+        else
+            rlLog "Skipping ML-DSA-65 verification (not available in FIPS mode)"
+        fi
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/Sanity/tang-pin-hybrid-TLS/runtest.sh
+++ b/Sanity/tang-pin-hybrid-TLS/runtest.sh
@@ -82,7 +82,7 @@ rlJournalStart
         done
         [ -n "$https_port" ] || { rlLogFatal "No free port for Nginx"; rlDie; }
         MLDSA_SSL_LINES=""
-        if $MLDSA_AVAILABLE; then
+        if [ "$MLDSA_AVAILABLE" = true ]; then
             MLDSA_SSL_LINES="    ssl_certificate     $(pwd)/server_mldsa.crt;
     ssl_certificate_key $(pwd)/server_mldsa.key;"
         fi
@@ -151,7 +151,7 @@ CLEVIS_END
         rlRun "grep 'SSL connection using.*RSA' rsa_debug.log" \
             0 "Verify RSA cipher was used"
         # ML-DSA-65
-        if $MLDSA_AVAILABLE; then
+        if [ "$MLDSA_AVAILABLE" = true ]; then
             rlRun "curl -v --cacert server_mldsa.crt  https://localhost:$https_port/adv/ 2> mldsa_debug.log" \
                 0 "Connect with ML-DSA signature algorithm"
             rlRun "grep 'SSL connection using.*id-ml-dsa-65' mldsa_debug.log" \

--- a/TestHelpers/utils.sh
+++ b/TestHelpers/utils.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
+_FIPS_CACHED=""
 is_fips_enabled() {
-    [ "$(cat /proc/sys/crypto/fips_enabled 2>/dev/null)" = "1" ]
+    if [ -z "$_FIPS_CACHED" ]; then
+        [ "$(cat /proc/sys/crypto/fips_enabled 2>/dev/null)" = "1" ] && _FIPS_CACHED=1 || _FIPS_CACHED=0
+    fi
+    [ "$_FIPS_CACHED" = "1" ]
 }
 
 create_hsm_config() {

--- a/TestHelpers/utils.sh
+++ b/TestHelpers/utils.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+is_fips_enabled() {
+    [ "$(cat /proc/sys/crypto/fips_enabled 2>/dev/null)" = "1" ]
+}
+
 create_hsm_config() {
     # Create a configuration file for the softhsm
 


### PR DESCRIPTION
Tests using RSA-PKCS (PKCS#1 v1.5) mechanism or ML-DSA-65 (post-quantum) algorithms fail in FIPS mode because these are not FIPS-compliant.

- Add is_fips_enabled() helper to TestHelpers/utils.sh
- pkcs11/basic: skip test in FIPS mode (RSA-PKCS not allowed, SoftHSM lacks RSA-PKCS-OAEP support)
- tang-pin-TLS: skip pqc_alg variant in FIPS mode (ML-DSA-65 not available)
- tang-pin-hybrid-TLS: gracefully degrade to 2-way hybrid (ECDSA+RSA) when ML-DSA-65 is unavailable in FIPS mode

## Summary by Sourcery

Handle FIPS mode constraints in pkcs11 and TLS-related tests by skipping or degrading non-FIPS algorithms and centralizing FIPS detection.

New Features:
- Add a reusable is_fips_enabled helper in TestHelpers/utils.sh for detecting FIPS mode.

Bug Fixes:
- Skip pkcs11/basic RSA-PKCS tests in FIPS mode to avoid using non-FIPS-compliant mechanisms.
- Skip tang-pin-TLS tests using ML-DSA-65 when running in FIPS mode where the algorithm is unavailable.
- Gracefully fall back to ECDSA+RSA-only hybrid TLS in tang-pin-hybrid-TLS when ML-DSA-65 is not available in FIPS mode, avoiding test failures.