### PR TITLE
Improve upstream-test-suite robustness and diagnostics

### DIFF
--- a/Sanity/upstream-test-suite/main.fmf
+++ b/Sanity/upstream-test-suite/main.fmf
@@ -11,7 +11,9 @@ recommend:
   - grep
   - patch
   - lsof
-duration: 10m
+  - socat
+  - softhsm
+duration: 30m
 enabled: true
 tag:
   - NoRHEL4

--- a/Sanity/upstream-test-suite/runtest.sh
+++ b/Sanity/upstream-test-suite/runtest.sh
@@ -68,7 +68,9 @@ rlJournalStart
             rlRun "mkdir build"
             rlRun "pushd build"
                 rlRun "meson .."
-                rlRun "meson test" 0 "Running upstream test suite"
+                rlRun "meson test --timeout-multiplier 3" 0 "Running upstream test suite"
+                rlRun "cp meson-logs/testlog.txt ${TmpDir}/testlog.txt" 0,1 "Preserve meson test log"
+                rlFileSubmit "${TmpDir}/testlog.txt" "meson-testlog.txt"
             rlRun "popd"
         rlRun "popd"
     rlPhaseEnd


### PR DESCRIPTION
Add socat and softhsm to recommended packages so meson tests that depend on tang (via socat) and PKCS#11 (via softhsm) run instead of being silently skipped.  Increase TMT duration from 10m to 30m to prevent slow architectures (s390x, aarch64) from being killed mid-run.  Use --timeout-multiplier 3 for meson test to accommodate resource-constrained VMs.  Preserve meson-logs/testlog.txt via rlFileSubmit so future failures can be diagnosed without re-running.

## Summary by Sourcery

Improve robustness and diagnostics of the upstream test suite run.

Enhancements:
- Increase meson test timeout via a timeout multiplier to better handle slow or resource-constrained environments.
- Preserve meson test logs and submit them as artifacts for easier diagnosis of failures.