### PR TITLE
boot-unlock-all-pins: add multi-Tang-slot boot test for RHEL-186032

### DIFF
--- a/Other/clevis-boot-unlock-all-pins/clevis-boot-unlock-all-pins
+++ b/Other/clevis-boot-unlock-all-pins/clevis-boot-unlock-all-pins
@@ -45,6 +45,20 @@ EOF
         sleep 0.1
       done
     done
+    # Add a second standalone Tang binding to exercise the
+    # SIGPIPE fix in have_tang_bindings. Only on releases that carry the fix.
+    source /etc/os-release
+    if [ "${VERSION_ID%%.*}" -ge 11 ] || \
+       { [ "${VERSION_ID%%.*}" -eq 10 ] && [ "${VERSION_ID#*.}" -ge 3 ]; }; then
+      for dev in $(blkid -t TYPE=crypto_LUKS -o device); do
+        attempts=0
+        until clevis luks bind -f -d "${dev}" tang '{"url":"https://'"${TANG_SERVER}"'","adv":"adv.jws"}' <<< '@LUKS_PW@'; do
+          attempts=$((attempts+1))
+          [ "${attempts}" -ge "${max_attempts}" ] && break
+          sleep 0.1
+        done
+      done
+    fi
     # Enable clevis-luks-askpass.
     systemctl enable clevis-luks-askpass.path ||:
     echo 'kernel_cmdline="rd.neednet=1"' > /etc/dracut.conf.d/10mt-ks-post-clevis.conf

--- a/Other/clevis-boot-unlock-all-pins/main.fmf
+++ b/Other/clevis-boot-unlock-all-pins/main.fmf
@@ -9,6 +9,8 @@ require:
     url: https://github.com/RedHat-SP-Security/clevis-tests
     type: library
   - socat
+link:
+  - verifies: https://issues.redhat.com/browse/RHEL-186032
 duration: 2h
 enabled: true
 tag:

--- a/Other/clevis-boot-unlock-all-pins/runtest.sh
+++ b/Other/clevis-boot-unlock-all-pins/runtest.sh
@@ -223,6 +223,12 @@ EOF
         rlRun "vmCmd ${ADDR} journalctl -b | grep \"clevis-luks-askpass.service: Deactivated successfully\""
       fi
 
+      # ensures clevis waits for network before contacting the Tang server.
+      # The observable proof is the absence of "Error communicating" messages.
+      if rlIsRHELLike '>=10.3'; then
+        rlRun "vmCmd ${ADDR} 'journalctl -b | grep \"Error communicating with server\"'" 1
+      fi
+
       # Now we setup any extra VM repos.
       if [ -n "${EXTRA_VM_REPOS}" ]; then
         count=0


### PR DESCRIPTION
On RHEL >= 10.3, add a second standalone Tang binding per LUKS device to exercise the SIGPIPE fix in have_tang_bindings. On older releases the test runs as before with a single binding.

Add version-gated post-boot assertion verifying no "Error communicating with server" messages in boot journal, proving clevis correctly waits for network before contacting the Tang server.

## Summary by Sourcery

Tests:
- Extend the clevis boot-unlock-all-pins test to assert no "Error communicating with server" messages appear in the boot journal on RHEL 10.3 and later.